### PR TITLE
feat: Add minimal /init slash command

### DIFF
--- a/source/app.tsx
+++ b/source/app.tsx
@@ -19,6 +19,7 @@ import {
   create as createTool,
   mcp,
   fetch as fetchTool,
+  init,
   SKIP_CONFIRMATION,
 } from "./tools/index.ts";
 import { useShallow } from "zustand/react/shallow";
@@ -381,6 +382,7 @@ function ToolMessageRenderer({ item }: { item: ToolCallItem }) {
     case "create": return <CreateToolRenderer item={item.tool.function} />
     case "mcp": return <McpToolRenderer item={item.tool.function} />
     case "fetch": return <FetchToolRenderer item={item.tool.function} />
+    case "init": return <InitToolRenderer item={item.tool.function} />
   }
 }
 
@@ -483,6 +485,14 @@ function McpToolRenderer({ item }: { item: t.GetType<typeof mcp.Schema> }) {
       <Text color={themeColor}>Server: {item.arguments.server}, Tool: {item.arguments.tool}</Text>
     </Box>
     <Text color="gray">Arguments: {JSON.stringify(item.arguments.arguments)}</Text>
+  </Box>
+}
+
+function InitToolRenderer({ item }: { item: t.GetType<typeof init.Schema> }) {
+  const themeColor = useColor();
+  return <Box>
+    <Text color="gray">{item.name}: </Text>
+    <Text color={themeColor}>{item.arguments.projectPath || "current directory"}</Text>
   </Box>
 }
 

--- a/source/ir/llm-ir.ts
+++ b/source/ir/llm-ir.ts
@@ -222,6 +222,16 @@ function collapseToIR(
         case "list":
         case "bash":
         case "mcp":
+        case "init":
+          return [
+            prev,
+            {
+              role: "tool-output",
+              content: item.content,
+              toolCall: prev.toolCall,
+            }
+          ];
+        default:
           return [
             prev,
             {

--- a/source/state.ts
+++ b/source/state.ts
@@ -69,21 +69,17 @@ export const useAppStore = create<UiState>((set, get) => ({
       const [command, ...args] = trimmed.split(' ');
       
       if (command === 'init') {
-        // Handle /init command directly as a tool call
+        // Handle /init command as a complete conversation flow
         const toolCallId = sequenceId().toString();
-        const toolCallItem: ToolCallItem = {
-          type: "tool",
-          id: sequenceId(),
-          tool: {
-            type: "function",
-            function: {
-              name: "init",
-              arguments: {
-                projectPath: args.length > 0 ? args.join(' ') : undefined,
-              }
-            },
-            toolCallId: toolCallId
-          }
+        const toolCallRequest = {
+          type: "function" as const,
+          function: {
+            name: "init" as const,
+            arguments: {
+              projectPath: args.length > 0 ? args.join(' ') : undefined,
+            }
+          },
+          toolCallId: toolCallId
         };
         
         const userMessage: UserItem = {
@@ -92,9 +88,24 @@ export const useAppStore = create<UiState>((set, get) => ({
           content: query,
         };
 
+        // Create an assistant message and tool call item that will be collapsed by toLlmIR
+        const assistantMessage: AssistantItem = {
+          type: "assistant",
+          id: sequenceId(),
+          content: `I'll initialize the project documentation for you.`,
+          tokenUsage: 0, // No real LLM tokens used for slash commands
+        };
+
+        const toolCallItem: ToolCallItem = {
+          type: "tool",
+          id: sequenceId(),
+          tool: toolCallRequest
+        };
+
         let history = [
           ...get().history,
           userMessage,
+          assistantMessage,
           toolCallItem,
         ];
         
@@ -254,6 +265,8 @@ export const useAppStore = create<UiState>((set, get) => ({
 
     let history: HistoryItem[];
     const modelConfig = getModelFromConfig(config, get().modelOverride);
+    
+    
     try {
       const run = (() => {
         if(modelConfig.type == null || modelConfig.type === "standard") return runAgent;
@@ -313,6 +326,7 @@ export const useAppStore = create<UiState>((set, get) => ({
         });
         return;
       }
+
 
       logger.error("verbose", e);
       set({

--- a/source/state.ts
+++ b/source/state.ts
@@ -63,6 +63,47 @@ export const useAppStore = create<UiState>((set, get) => ({
   modelOverride: null,
 
   input: async ({ config, query }) => {
+    // Check if this is a slash command
+    if (query.trim().startsWith('/')) {
+      const trimmed = query.trim().slice(1); // Remove '/'
+      const [command, ...args] = trimmed.split(' ');
+      
+      if (command === 'init') {
+        // Handle /init command directly as a tool call
+        const toolCallId = sequenceId().toString();
+        const toolCallItem: ToolCallItem = {
+          type: "tool",
+          id: sequenceId(),
+          tool: {
+            type: "function",
+            function: {
+              name: "init",
+              arguments: {
+                projectPath: args.length > 0 ? args.join(' ') : undefined,
+              }
+            },
+            toolCallId: toolCallId
+          }
+        };
+        
+        const userMessage: UserItem = {
+          type: "user",
+          id: sequenceId(),
+          content: query,
+        };
+
+        let history = [
+          ...get().history,
+          userMessage,
+          toolCallItem,
+        ];
+        
+        set({ history });
+        await get().runTool({ config, toolReq: toolCallItem });
+        return;
+      }
+    }
+
     const userMessage: UserItem = {
 			type: "user",
       id: sequenceId(),

--- a/source/tools/tool-defs/index.ts
+++ b/source/tools/tool-defs/index.ts
@@ -5,3 +5,4 @@ export { default as edit } from "./edit.ts";
 export { default as create } from "./create.ts";
 export { default as mcp } from "./mcp.ts";
 export { default as fetch } from "./fetch.ts";
+export { default as init } from "./init.ts";

--- a/source/tools/tool-defs/init.e2e.test.ts
+++ b/source/tools/tool-defs/init.e2e.test.ts
@@ -1,0 +1,256 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { tmpdir } from "os";
+import init from "./init.ts";
+import { Config } from "../../config.ts";
+
+describe("Init E2E Test - Reproducing Infinite Retry Issue", () => {
+  let tempDir: string;
+  let mockConfig: any; // Use any to avoid complex Config typing
+
+  beforeEach(async () => {
+    // Create a temporary directory for testing
+    tempDir = await fs.mkdtemp(path.join(tmpdir(), "octofriend-init-test-"));
+    
+    // Create a mock config that mimics the real octofriend config
+    mockConfig = {
+      yourName: "Test User",
+      models: [
+        {
+          nickname: "test-model",
+          baseUrl: "http://localhost:8080/v1",
+          model: "test-model",
+          contextWindow: 8192,
+        }
+      ],
+      mcpServers: {
+        "memory": {
+          command: "npx",
+          args: ["-y", "@modelcontextprotocol/server-memory"]
+        },
+        "filesystem": {
+          command: "npx", 
+          args: ["-y", "@modelcontextprotocol/server-filesystem", tempDir]
+        }
+      }
+    };
+    
+    // Create a simple package.json to make it a proper project
+    await fs.writeFile(
+      path.join(tempDir, "package.json"),
+      JSON.stringify({
+        name: "test-project",
+        description: "Test project for init command",
+        scripts: {
+          build: "echo 'building'",
+          test: "echo 'testing'"
+        },
+        dependencies: {
+          "react": "^18.0.0"
+        },
+        devDependencies: {
+          "typescript": "^5.0.0"
+        }
+      }, null, 2)
+    );
+
+    // Create typical project directories
+    await fs.mkdir(path.join(tempDir, "src"));
+    await fs.mkdir(path.join(tempDir, "tests"));
+    await fs.writeFile(path.join(tempDir, "tsconfig.json"), "{}");
+  });
+
+  afterEach(async () => {
+    // Clean up temp directory
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch (e) {
+      // Ignore cleanup errors
+    }
+  });
+
+  it("should execute init tool and return formatted output that doesn't cause LLM failures", async () => {
+    console.log("=== E2E TEST: Starting init tool execution ===");
+    
+    // Create the tool call that matches what state.ts creates for slash commands
+    const toolCall = {
+      tool: {
+        name: "init" as const,
+        arguments: {
+          projectPath: tempDir
+        }
+      }
+    };
+
+    const abortController = new AbortController();
+    
+    console.log("=== E2E TEST: Executing init tool ===");
+    console.log("Project path:", tempDir);
+    
+    let toolOutput: string = "";
+    let error: any = null;
+    
+    try {
+      // Execute the init tool exactly as state.ts does
+      // Use "." as the path to avoid path traversal issues with temp dirs
+      const toolCallWithCurrentDir = {
+        tool: {
+          name: "init" as const,
+          arguments: {
+            projectPath: "." // Use current directory instead
+          }
+        }
+      };
+      
+      toolOutput = await init.run(
+        abortController.signal,
+        { id: 1n, tool: toolCallWithCurrentDir.tool },
+        mockConfig,
+        null
+      );
+      
+      console.log("=== E2E TEST: Tool output received ===");
+      console.log("Output length:", toolOutput.length);
+      console.log("Output preview:", toolOutput.substring(0, 200) + "...");
+      console.log("Output line count:", toolOutput.split("\n").length);
+      
+    } catch (e) {
+      error = e;
+      console.error("=== E2E TEST: Tool execution failed ===");
+      console.error("Error:", e);
+    }
+
+    // Verify tool executed successfully
+    expect(error).toBeNull();
+    expect(toolOutput).toBeDefined();
+    expect(toolOutput).toContain("Project initialized successfully!");
+    
+    // Verify OCTO.md was created in current directory
+    const octoPath = path.join(process.cwd(), "OCTO.md");
+    const octoExists = await fs.access(octoPath).then(() => true).catch(() => false);
+    expect(octoExists).toBe(true);
+    
+    console.log("=== E2E TEST: Simulating state.ts tool processing ===");
+    
+    // Simulate what state.ts does after tool execution
+    const toolHistoryItem = {
+      type: "tool-output" as const,
+      id: 123,
+      content: toolOutput,
+      toolCallId: "test-call-id",
+    };
+    
+    console.log("Tool history item created:", {
+      type: toolHistoryItem.type,
+      contentLength: toolHistoryItem.content.length,
+      contentPreview: toolHistoryItem.content.substring(0, 100) + "..."
+    });
+    
+    // Test that the output format is what causes issues
+    // This simulates the LLM message conversion
+    console.log("=== E2E TEST: Testing LLM message conversion ===");
+    
+    // Check for problematic characters or formatting
+    const hasEmoji = /[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E0}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]/u.test(toolOutput);
+    const hasSpecialChars = /[^\x20-\x7E\n\r\t]/g.test(toolOutput);
+    const startsWithSpecialChar = !/^[a-zA-Z0-9]/.test(toolOutput.trim());
+    
+    console.log("Output analysis:");
+    console.log("- Contains emoji:", hasEmoji);
+    console.log("- Contains special chars:", hasSpecialChars);
+    console.log("- Starts with special char:", startsWithSpecialChar);
+    console.log("- First char code:", toolOutput.trim().charCodeAt(0));
+    console.log("- First 50 chars:", JSON.stringify(toolOutput.substring(0, 50)));
+    
+    // Test JSON serialization (what might happen in LLM requests)
+    try {
+      const jsonTest = JSON.stringify({ content: toolOutput });
+      const parsed = JSON.parse(jsonTest);
+      expect(parsed.content).toBe(toolOutput);
+      console.log("JSON serialization: SUCCESS");
+    } catch (e) {
+      console.error("JSON serialization: FAILED", e);
+      throw new Error(`Tool output fails JSON serialization: ${e}`);
+    }
+    
+    // Test if the output could cause parsing issues
+    const lines = toolOutput.split('\n');
+    console.log("Output structure:");
+    console.log("- Total lines:", lines.length);
+    console.log("- First line:", JSON.stringify(lines[0]));
+    console.log("- Last line:", JSON.stringify(lines[lines.length - 1]));
+    
+    // This test will help identify what specific aspect of the tool output
+    // is causing the LLM request failures and infinite retry loops
+    console.log("=== E2E TEST: Complete - output format validated ===");
+  });
+
+  it("should handle the exact slash command flow", async () => {
+    console.log("=== E2E TEST: Testing slash command flow simulation ===");
+    
+    // This test simulates the exact flow from state.ts input() function
+    const query = "/init";
+    const trimmed = query.trim().slice(1); // Remove '/'
+    const [command, ...args] = trimmed.split(' ');
+    
+    expect(command).toBe("init");
+    
+    // Simulate the tool call creation from state.ts
+    const toolCallId = "test-call-id";
+    const toolCallItem = {
+      type: "tool" as const,
+      id: 456,
+      tool: {
+        type: "function" as const,
+        function: {
+          name: "init" as const,
+          arguments: {
+            projectPath: args.length > 0 ? args.join(' ') : undefined,
+          }
+        },
+        toolCallId: toolCallId
+      }
+    };
+    
+    console.log("Tool call item created:", toolCallItem);
+    
+    // Execute tool as runTool does
+    const abortController = new AbortController();
+    
+    const content = await init.run(
+      abortController.signal,
+      {
+        id: BigInt(toolCallItem.id),
+        tool: toolCallItem.tool.function,
+      },
+      mockConfig,
+      null
+    );
+    
+    console.log("Tool execution result:");
+    console.log("- Content length:", content.length);
+    console.log("- Content preview:", content.substring(0, 150));
+    
+    // Create tool output history item as state.ts does
+    const toolHistoryItem = {
+      type: "tool-output" as const,
+      id: 789,
+      content,
+      toolCallId: toolCallItem.tool.toolCallId,
+    };
+    
+    console.log("Created tool history item with:", {
+      type: toolHistoryItem.type,
+      contentLength: toolHistoryItem.content.length,
+      toolCallId: toolHistoryItem.toolCallId
+    });
+    
+    // At this point, state.ts would call _runAgent({ config })
+    // which processes the history including this tool output item
+    // and sends it to the LLM - this is where the failure occurs
+    
+    console.log("=== E2E TEST: Ready for _runAgent simulation ===");
+    console.log("History would contain tool-output item that causes LLM failure");
+  });
+});

--- a/source/tools/tool-defs/init.flow.test.ts
+++ b/source/tools/tool-defs/init.flow.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { toLlmIR } from "../../ir/llm-ir.ts";
+import { HistoryItem, sequenceId } from "../../history.ts";
+
+describe("Init Command Message Flow", () => {
+  it("should create proper LLM message flow for slash commands", () => {
+    console.log("=== MESSAGE FLOW TEST ===");
+    
+    // Simulate the history that gets created by the slash command fix
+    const toolCallId = "test-call-id";
+    
+    const history: HistoryItem[] = [
+      {
+        type: "user",
+        id: sequenceId(),
+        content: "/init",
+      },
+      {
+        type: "assistant", 
+        id: sequenceId(),
+        content: "I'll initialize the project documentation for you.",
+        tokenUsage: 0,
+      },
+      {
+        type: "tool",
+        id: sequenceId(),
+        tool: {
+          type: "function",
+          function: {
+            name: "init",
+            arguments: {
+              projectPath: undefined,
+            }
+          },
+          toolCallId: toolCallId
+        }
+      },
+      {
+        type: "tool-output",
+        id: sequenceId(),
+        content: "Project initialized successfully!\n\nGenerated OCTO.md with:\n- Project: octofriend\n- Features: npm scripts, Node.js dependencies, Development dependencies, TypeScript\n- MCP Servers: 2 configured\n- File: OCTO.md\n\nThe OCTO.md file contains comprehensive project documentation including available MCP tools.",
+        toolCallId: toolCallId,
+      }
+    ];
+    
+    console.log("Input history items:");
+    history.forEach((item, i) => {
+      console.log(`  ${i}: ${item.type}`);
+    });
+    
+    // Convert to LLM IR
+    const llmIR = toLlmIR(history);
+    
+    console.log("LLM IR items:");
+    llmIR.forEach((item, i) => {
+      console.log(`  ${i}: ${item.role}${item.role === 'assistant' && (item as any).toolCall ? ' (with tool call)' : ''}`);
+    });
+    
+    // Verify the expected structure
+    expect(llmIR).toHaveLength(3);
+    
+    // Should be: user, assistant with tool call, tool-output
+    expect(llmIR[0].role).toBe("user");
+    expect((llmIR[0] as any).content).toBe("/init");
+    
+    expect(llmIR[1].role).toBe("assistant");
+    expect((llmIR[1] as any).content).toBe("I'll initialize the project documentation for you.");
+    expect((llmIR[1] as any).toolCall).toBeDefined();
+    expect((llmIR[1] as any).toolCall.function.name).toBe("init");
+    expect((llmIR[1] as any).toolCall.toolCallId).toBe(toolCallId);
+    
+    expect(llmIR[2].role).toBe("tool-output");
+    expect((llmIR[2] as any).content).toContain("Project initialized successfully!");
+    expect((llmIR[2] as any).toolCall.toolCallId).toBe(toolCallId);
+    
+    console.log("✅ Message flow is correct!");
+    
+    // Now verify that this would convert to proper LLM messages
+    // (We can't easily test llmFromIr without more setup, but the structure is correct)
+    
+    console.log("Expected LLM API call structure:");
+    console.log("1. User message: '/init'");
+    console.log("2. Assistant message with tool_calls: [{name: 'init', id: '" + toolCallId + "'}]");
+    console.log("3. Tool message: {role: 'tool', tool_call_id: '" + toolCallId + "', content: '...'}");
+    
+    console.log("=== MESSAGE FLOW TEST COMPLETE ===");
+  });
+});

--- a/source/tools/tool-defs/init.test.ts
+++ b/source/tools/tool-defs/init.test.ts
@@ -1,0 +1,494 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { withMock } from 'antipattern';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import * as os from 'os';
+import initTool from './init.ts';
+import { Config } from '../../config.ts';
+import { ToolError } from '../common.ts';
+
+describe('init tool security tests', () => {
+  let tempDir: string;
+  let mockConfig: Config;
+  let mockAbortSignal: AbortSignal;
+
+  beforeEach(async () => {
+    // Create temporary directory for testing
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'init-test-'));
+    
+    mockConfig = {
+      mcpServers: {
+        'test-server': {
+          command: 'echo',
+          args: ['test']
+        }
+      }
+    } as Config;
+
+    mockAbortSignal = new AbortController().signal;
+  });
+
+  afterEach(async () => {
+    // Clean up temporary directory
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      console.warn('Failed to clean up temp dir:', error);
+    }
+  });
+
+  describe('path traversal protection', () => {
+    it('should reject path traversal attempts with ../../../../', async () => {
+      const attack = '../../../../etc';
+      
+      await expect(
+        initTool.run(mockAbortSignal, {
+          tool: { 
+            name: 'init',
+            arguments: { projectPath: attack }
+          }
+        }, mockConfig)
+      ).rejects.toThrow('Project initialization failed. Please check the project path and permissions.');
+    });
+
+    it('should reject path traversal attempts with ../../../home', async () => {
+      const attack = '../../../home/user/.ssh';
+      
+      await expect(
+        initTool.run(mockAbortSignal, {
+          tool: { 
+            name: 'init',
+            arguments: { projectPath: attack }
+          }
+        }, mockConfig)
+      ).rejects.toThrow('Project initialization failed. Please check the project path and permissions.');
+    });
+
+    it('should reject absolute path attempts outside current directory', async () => {
+      const attack = '/etc/passwd';
+      
+      await expect(
+        initTool.run(mockAbortSignal, {
+          tool: { 
+            name: 'init',
+            arguments: { projectPath: attack }
+          }
+        }, mockConfig)
+      ).rejects.toThrow('Project initialization failed. Please check the project path and permissions.');
+    });
+
+    it('should allow legitimate relative paths within current directory', async () => {
+      // Create a test project structure
+      const projectName = 'test-project';
+      const projectPath = path.join(tempDir, projectName);
+      await fs.mkdir(projectPath, { recursive: true });
+      
+      // Create package.json
+      const packageJson = {
+        name: projectName,
+        description: 'Test project',
+        scripts: {
+          test: 'vitest',
+          build: 'tsc'
+        }
+      };
+      await fs.writeFile(
+        path.join(projectPath, 'package.json'),
+        JSON.stringify(packageJson, null, 2)
+      );
+
+      // Mock process.cwd() to return tempDir
+      const originalCwd = process.cwd;
+      process.cwd = () => tempDir;
+
+      try {
+        const result = await initTool.run(mockAbortSignal, {
+          tool: { 
+            name: 'init',
+            arguments: { projectPath: projectName }
+          }
+        }, mockConfig);
+
+        expect(result).toContain('Project initialized successfully');
+        expect(result).toContain(projectName);
+        
+        // Verify OCTO.md was created
+        const octoPath = path.join(projectPath, 'OCTO.md');
+        const octoContent = await fs.readFile(octoPath, 'utf-8');
+        expect(octoContent).toContain(`# ${projectName}`);
+      } finally {
+        process.cwd = originalCwd;
+      }
+    });
+  });
+
+  describe('input validation', () => {
+    it('should reject paths with invalid characters', async () => {
+      const invalidInputs = [
+        'path; rm -rf /',
+        'path && rm -rf /',
+        'path | cat /etc/passwd',
+        'path `cat /etc/passwd`',
+        'path$(whoami)',
+        'path\x00null'
+      ];
+
+      for (const invalidPath of invalidInputs) {
+        await expect(
+          initTool.run(mockAbortSignal, {
+            tool: { 
+              name: 'init',
+              arguments: { projectPath: invalidPath }
+            }
+          }, mockConfig)
+        ).rejects.toThrow('Project initialization failed. Please check the project path and permissions.');
+      }
+    });
+
+    it('should reject excessively long paths', async () => {
+      const longPath = 'a'.repeat(300);
+      
+      await expect(
+        initTool.run(mockAbortSignal, {
+          tool: { 
+            name: 'init',
+            arguments: { projectPath: longPath }
+          }
+        }, mockConfig)
+      ).rejects.toThrow('Project initialization failed. Please check the project path and permissions.');
+    });
+
+    it('should accept valid path characters', async () => {
+      // Create valid test project
+      const validPath = 'valid-project_123';
+      const projectPath = path.join(tempDir, validPath);
+      await fs.mkdir(projectPath, { recursive: true });
+
+      // Mock process.cwd() to return tempDir
+      const originalCwd = process.cwd;
+      process.cwd = () => tempDir;
+
+      try {
+        const result = await initTool.run(mockAbortSignal, {
+          tool: { 
+            name: 'init',
+            arguments: { projectPath: validPath }
+          }
+        }, mockConfig);
+
+        expect(result).toContain('Project initialized successfully');
+      } finally {
+        process.cwd = originalCwd;
+      }
+    });
+  });
+
+  describe('error information disclosure prevention', () => {
+    it('should not expose sensitive file paths in error messages', async () => {
+      // Mock fs operations to throw with sensitive path
+      const mockFs = {
+        readFile: async (path: string) => {
+          throw new Error(`ENOENT: no such file or directory, open '${path}'`);
+        },
+        writeFile: async () => {},
+        stat: async () => ({ isDirectory: () => false }),
+        access: async () => { throw new Error('Access denied'); }
+      };
+
+      await withMock({ fs }, 'fs', mockFs, async () => {
+        try {
+          await initTool.run(mockAbortSignal, {
+            tool: { 
+              name: 'init',
+              arguments: { projectPath: 'test-path' }
+            }
+          }, mockConfig);
+        } catch (error) {
+          expect(error).toBeInstanceOf(ToolError);
+          expect(error.message).toBe('Project initialization failed. Please check the project path and permissions.');
+          expect(error.message).not.toContain('/etc');
+          expect(error.message).not.toContain('/home');
+          expect(error.message).not.toContain('ENOENT');
+        }
+      });
+    });
+  });
+
+  describe('directory whitelist security', () => {
+    it('should only process whitelisted directory names', async () => {
+      // Create temporary project with both allowed and potentially dangerous dirs
+      const projectPath = path.join(tempDir, 'test-project');
+      await fs.mkdir(projectPath, { recursive: true });
+      
+      const allowedDirs = ['src', 'source', 'lib', 'test', 'build'];
+      const dangerousDirs = ['../../../etc', '$(whoami)', '`cat /etc/passwd`'];
+      
+      // Create allowed directories
+      for (const dir of allowedDirs) {
+        await fs.mkdir(path.join(projectPath, dir), { recursive: true });
+      }
+      
+      // Mock process.cwd() to return tempDir
+      const originalCwd = process.cwd;
+      process.cwd = () => tempDir;
+
+      try {
+        const result = await initTool.run(mockAbortSignal, {
+          tool: { 
+            name: 'init',
+            arguments: { projectPath: 'test-project' }
+          }
+        }, mockConfig);
+
+        expect(result).toContain('Project initialized successfully');
+        
+        // Verify OCTO.md contains only allowed directories
+        const octoPath = path.join(projectPath, 'OCTO.md');
+        const octoContent = await fs.readFile(octoPath, 'utf-8');
+        
+        for (const dir of allowedDirs) {
+          expect(octoContent).toContain(dir);
+        }
+        
+        // Ensure no dangerous paths leaked through
+        for (const dangerousDir of dangerousDirs) {
+          expect(octoContent).not.toContain(dangerousDir);
+        }
+      } finally {
+        process.cwd = originalCwd;
+      }
+    });
+  });
+
+  describe('race condition handling', () => {
+    it('should handle concurrent file operations gracefully', async () => {
+      // Create test project
+      const projectPath = path.join(tempDir, 'race-test');
+      await fs.mkdir(projectPath, { recursive: true });
+      
+      // Create package.json
+      await fs.writeFile(
+        path.join(projectPath, 'package.json'),
+        JSON.stringify({ name: 'race-test' })
+      );
+
+      // Mock process.cwd() to return tempDir
+      const originalCwd = process.cwd;
+      process.cwd = () => tempDir;
+
+      try {
+        // Run multiple init operations concurrently
+        const promises = Array(5).fill(0).map(() => 
+          initTool.run(mockAbortSignal, {
+            tool: { 
+              name: 'init',
+              arguments: { projectPath: 'race-test' }
+            }
+          }, mockConfig)
+        );
+
+        const results = await Promise.allSettled(promises);
+        
+        // At least one should succeed
+        const successful = results.filter(r => r.status === 'fulfilled');
+        expect(successful.length).toBeGreaterThan(0);
+        
+        // Verify OCTO.md exists and is valid
+        const octoPath = path.join(projectPath, 'OCTO.md');
+        const octoContent = await fs.readFile(octoPath, 'utf-8');
+        expect(octoContent).toContain('# race-test');
+      } finally {
+        process.cwd = originalCwd;
+      }
+    });
+  });
+});
+
+describe('init tool functional tests', () => {
+  let tempDir: string;
+  let mockConfig: Config;
+  let mockAbortSignal: AbortSignal;
+
+  beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'init-func-test-'));
+    mockConfig = { mcpServers: {} } as Config;
+    mockAbortSignal = new AbortController().signal;
+  });
+
+  afterEach(async () => {
+    try {
+      await fs.rm(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      console.warn('Failed to clean up temp dir:', error);
+    }
+  });
+
+  describe('OCTO.md generation', () => {
+    it('should generate comprehensive OCTO.md for TypeScript project', async () => {
+      // Create comprehensive test project
+      const projectPath = path.join(tempDir, 'typescript-project');
+      await fs.mkdir(projectPath, { recursive: true });
+      
+      // Create project structure
+      const dirs = ['src', 'test', 'dist', 'lib'];
+      for (const dir of dirs) {
+        await fs.mkdir(path.join(projectPath, dir), { recursive: true });
+      }
+      
+      // Create package.json with comprehensive metadata
+      const packageJson = {
+        name: 'typescript-project',
+        description: 'A comprehensive TypeScript project for testing',
+        version: '1.0.0',
+        scripts: {
+          build: 'tsc',
+          test: 'vitest',
+          dev: 'tsx src/index.ts',
+          lint: 'eslint src/'
+        },
+        dependencies: {
+          'react': '^18.0.0',
+          'lodash': '^4.17.21'
+        },
+        devDependencies: {
+          'typescript': '^5.0.0',
+          'vitest': '^1.0.0',
+          '@types/node': '^20.0.0'
+        }
+      };
+      
+      await fs.writeFile(
+        path.join(projectPath, 'package.json'),
+        JSON.stringify(packageJson, null, 2)
+      );
+      
+      // Create tsconfig.json
+      const tsconfig = {
+        compilerOptions: {
+          target: 'ES2022',
+          module: 'ESNext',
+          outDir: './dist'
+        }
+      };
+      
+      await fs.writeFile(
+        path.join(projectPath, 'tsconfig.json'),
+        JSON.stringify(tsconfig, null, 2)
+      );
+
+      // Mock process.cwd() to return tempDir
+      const originalCwd = process.cwd;
+      process.cwd = () => tempDir;
+
+      try {
+        const result = await initTool.run(mockAbortSignal, {
+          tool: { 
+            name: 'init',
+            arguments: { projectPath: 'typescript-project' }
+          }
+        }, mockConfig);
+
+        expect(result).toContain('Project initialized successfully');
+        expect(result).toContain('typescript-project');
+        
+        // Verify OCTO.md content
+        const octoPath = path.join(projectPath, 'OCTO.md');
+        const octoContent = await fs.readFile(octoPath, 'utf-8');
+        
+        // Check header
+        expect(octoContent).toContain('# typescript-project');
+        expect(octoContent).toContain('A comprehensive TypeScript project for testing');
+        
+        // Check features
+        expect(octoContent).toContain('npm scripts');
+        expect(octoContent).toContain('Node.js dependencies');
+        expect(octoContent).toContain('Development dependencies');
+        expect(octoContent).toContain('TypeScript');
+        
+        // Check project structure
+        expect(octoContent).toContain('## Project Structure');
+        for (const dir of dirs) {
+          expect(octoContent).toContain(`**${dir}**: directory`);
+        }
+        
+        // Check scripts
+        expect(octoContent).toContain('**script:build**: tsc');
+        expect(octoContent).toContain('**script:test**: vitest');
+        
+        // Check dependencies count
+        expect(octoContent).toContain('**dependencies**: 2');
+        expect(octoContent).toContain('**devDependencies**: 3');
+        
+        // Check footer
+        expect(octoContent).toContain('Generated by octofriend `/init` command');
+      } finally {
+        process.cwd = originalCwd;
+      }
+    });
+
+    it('should handle minimal project without package.json', async () => {
+      // Create minimal project with just directories
+      const projectPath = path.join(tempDir, 'minimal-project');
+      await fs.mkdir(projectPath, { recursive: true });
+      
+      const srcDir = path.join(projectPath, 'src');
+      await fs.mkdir(srcDir, { recursive: true });
+
+      // Mock process.cwd() to return tempDir
+      const originalCwd = process.cwd;
+      process.cwd = () => tempDir;
+
+      try {
+        const result = await initTool.run(mockAbortSignal, {
+          tool: { 
+            name: 'init',
+            arguments: { projectPath: 'minimal-project' }
+          }
+        }, mockConfig);
+
+        expect(result).toContain('Project initialized successfully');
+        
+        const octoPath = path.join(projectPath, 'OCTO.md');
+        const octoContent = await fs.readFile(octoPath, 'utf-8');
+        
+        expect(octoContent).toContain('# minimal-project');
+        expect(octoContent).toContain('**src**: directory');
+        expect(octoContent).toContain('Generated by octofriend `/init` command');
+      } finally {
+        process.cwd = originalCwd;
+      }
+    });
+  });
+
+  describe('default path handling', () => {
+    it('should use current directory when no projectPath provided', async () => {
+      // Create package.json in temp directory
+      await fs.writeFile(
+        path.join(tempDir, 'package.json'),
+        JSON.stringify({ name: 'current-dir-test' })
+      );
+
+      // Mock process.cwd() to return tempDir
+      const originalCwd = process.cwd;
+      process.cwd = () => tempDir;
+
+      try {
+        const result = await initTool.run(mockAbortSignal, {
+          tool: { 
+            name: 'init',
+            arguments: {} // No projectPath provided
+          }
+        }, mockConfig);
+
+        expect(result).toContain('Project initialized successfully');
+        
+        const octoPath = path.join(tempDir, 'OCTO.md');
+        const octoContent = await fs.readFile(octoPath, 'utf-8');
+        
+        expect(octoContent).toContain('# current-dir-test');
+      } finally {
+        process.cwd = originalCwd;
+      }
+    });
+  });
+});

--- a/source/tools/tool-defs/init.test.ts
+++ b/source/tools/tool-defs/init.test.ts
@@ -17,6 +17,13 @@ describe('init tool security tests', () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'init-test-'));
     
     mockConfig = {
+      yourName: 'test-user',
+      models: [{
+        nickname: 'test-model',
+        baseUrl: 'http://localhost',
+        model: 'test',
+        context: 4096
+      }],
       mcpServers: {
         'test-server': {
           command: 'echo',
@@ -46,8 +53,9 @@ describe('init tool security tests', () => {
           tool: { 
             name: 'init',
             arguments: { projectPath: attack }
-          }
-        }, mockConfig)
+          },
+          id: 1n
+        }, mockConfig, null)
       ).rejects.toThrow('Project initialization failed. Please check the project path and permissions.');
     });
 
@@ -59,8 +67,9 @@ describe('init tool security tests', () => {
           tool: { 
             name: 'init',
             arguments: { projectPath: attack }
-          }
-        }, mockConfig)
+          },
+          id: 2n
+        }, mockConfig, null)
       ).rejects.toThrow('Project initialization failed. Please check the project path and permissions.');
     });
 
@@ -72,8 +81,9 @@ describe('init tool security tests', () => {
           tool: { 
             name: 'init',
             arguments: { projectPath: attack }
-          }
-        }, mockConfig)
+          },
+          id: 3n
+        }, mockConfig, null)
       ).rejects.toThrow('Project initialization failed. Please check the project path and permissions.');
     });
 
@@ -106,8 +116,9 @@ describe('init tool security tests', () => {
           tool: { 
             name: 'init',
             arguments: { projectPath: projectName }
-          }
-        }, mockConfig);
+          },
+          id: 4n
+        }, mockConfig, null);
 
         expect(result).toContain('Project initialized successfully');
         expect(result).toContain(projectName);
@@ -133,14 +144,15 @@ describe('init tool security tests', () => {
         'path\x00null'
       ];
 
-      for (const invalidPath of invalidInputs) {
+      for (const [i, invalidPath] of invalidInputs.entries()) {
         await expect(
           initTool.run(mockAbortSignal, {
             tool: { 
               name: 'init',
               arguments: { projectPath: invalidPath }
-            }
-          }, mockConfig)
+            },
+            id: BigInt(i + 5)
+          }, mockConfig, null)
         ).rejects.toThrow('Project initialization failed. Please check the project path and permissions.');
       }
     });
@@ -153,8 +165,9 @@ describe('init tool security tests', () => {
           tool: { 
             name: 'init',
             arguments: { projectPath: longPath }
-          }
-        }, mockConfig)
+          },
+          id: 12n
+        }, mockConfig, null)
       ).rejects.toThrow('Project initialization failed. Please check the project path and permissions.');
     });
 
@@ -173,8 +186,9 @@ describe('init tool security tests', () => {
           tool: { 
             name: 'init',
             arguments: { projectPath: validPath }
-          }
-        }, mockConfig);
+          },
+          id: 13n
+        }, mockConfig, null);
 
         expect(result).toContain('Project initialized successfully');
       } finally {
@@ -187,13 +201,14 @@ describe('init tool security tests', () => {
     it('should not expose sensitive file paths in error messages', async () => {
       // Mock fs operations to throw with sensitive path
       const mockFs = {
+        ...fs,
         readFile: async (path: string) => {
           throw new Error(`ENOENT: no such file or directory, open '${path}'`);
         },
         writeFile: async () => {},
         stat: async () => ({ isDirectory: () => false }),
         access: async () => { throw new Error('Access denied'); }
-      };
+      } as unknown as typeof fs;
 
       await withMock({ fs }, 'fs', mockFs, async () => {
         try {
@@ -201,14 +216,15 @@ describe('init tool security tests', () => {
             tool: { 
               name: 'init',
               arguments: { projectPath: 'test-path' }
-            }
-          }, mockConfig);
+            },
+            id: 14n
+          }, mockConfig, null);
         } catch (error) {
           expect(error).toBeInstanceOf(ToolError);
-          expect(error.message).toBe('Project initialization failed. Please check the project path and permissions.');
-          expect(error.message).not.toContain('/etc');
-          expect(error.message).not.toContain('/home');
-          expect(error.message).not.toContain('ENOENT');
+          expect((error as ToolError).message).toBe('Project initialization failed. Please check the project path and permissions.');
+          expect((error as ToolError).message).not.toContain('/etc');
+          expect((error as ToolError).message).not.toContain('/home');
+          expect((error as ToolError).message).not.toContain('ENOENT');
         }
       });
     });
@@ -237,8 +253,9 @@ describe('init tool security tests', () => {
           tool: { 
             name: 'init',
             arguments: { projectPath: 'test-project' }
-          }
-        }, mockConfig);
+          },
+          id: 15n
+        }, mockConfig, null);
 
         expect(result).toContain('Project initialized successfully');
         
@@ -278,13 +295,14 @@ describe('init tool security tests', () => {
 
       try {
         // Run multiple init operations concurrently
-        const promises = Array(5).fill(0).map(() => 
+        const promises = Array(5).fill(0).map((_, i) => 
           initTool.run(mockAbortSignal, {
             tool: { 
               name: 'init',
               arguments: { projectPath: 'race-test' }
-            }
-          }, mockConfig)
+            },
+            id: BigInt(16 + i)
+          }, mockConfig, null)
         );
 
         const results = await Promise.allSettled(promises);
@@ -311,7 +329,16 @@ describe('init tool functional tests', () => {
 
   beforeEach(async () => {
     tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'init-func-test-'));
-    mockConfig = { mcpServers: {} } as Config;
+    mockConfig = {
+      yourName: 'test-user',
+      models: [{
+        nickname: 'test-model',
+        baseUrl: 'http://localhost',
+        model: 'test',
+        context: 4096
+      }],
+      mcpServers: {}
+    } as Config;
     mockAbortSignal = new AbortController().signal;
   });
 
@@ -385,8 +412,9 @@ describe('init tool functional tests', () => {
           tool: { 
             name: 'init',
             arguments: { projectPath: 'typescript-project' }
-          }
-        }, mockConfig);
+          },
+          id: 21n
+        }, mockConfig, null);
 
         expect(result).toContain('Project initialized successfully');
         expect(result).toContain('typescript-project');
@@ -443,8 +471,9 @@ describe('init tool functional tests', () => {
           tool: { 
             name: 'init',
             arguments: { projectPath: 'minimal-project' }
-          }
-        }, mockConfig);
+          },
+          id: 22n
+        }, mockConfig, null);
 
         expect(result).toContain('Project initialized successfully');
         
@@ -477,8 +506,9 @@ describe('init tool functional tests', () => {
           tool: { 
             name: 'init',
             arguments: {} // No projectPath provided
-          }
-        }, mockConfig);
+          },
+          id: 23n
+        }, mockConfig, null);
 
         expect(result).toContain('Project initialized successfully');
         

--- a/source/tools/tool-defs/init.ts
+++ b/source/tools/tool-defs/init.ts
@@ -14,14 +14,43 @@ const Schema = t.subtype({
   arguments: ArgumentsSchema,
 }).comment("Initialize project documentation by analyzing structure and discovering MCP tools");
 
+function validateProjectPath(projectPath: string): void {
+  // Check for dangerous characters
+  const dangerousChars = /[;&|`$(){}[\]\\<>'"]/;
+  if (dangerousChars.test(projectPath)) {
+    throw new ToolError("Invalid path characters detected");
+  }
+  
+  // Check length
+  if (projectPath.length > 255) {
+    throw new ToolError("Path too long");
+  }
+  
+  // Check for null bytes
+  if (projectPath.includes('\0')) {
+    throw new ToolError("Null bytes not allowed in path");
+  }
+}
+
+function validateAndResolvePath(basePath: string, ...segments: string[]): string {
+  const resolved = path.resolve(basePath, ...segments);
+  const baseResolved = path.resolve(basePath);
+  
+  if (!resolved.startsWith(baseResolved + path.sep) && resolved !== baseResolved) {
+    throw new ToolError(`Path traversal detected: ${segments.join('/')}`);
+  }
+  return resolved;
+}
+
 async function analyzeProject(projectPath: string): Promise<{
   name: string;
   description: string;
   features: string[];
   structure: Record<string, string>;
 }> {
-  const packageJsonPath = path.join(projectPath, "package.json");
-  const tsconfigPath = path.join(projectPath, "tsconfig.json");
+  const safeProjectPath = validateAndResolvePath(process.cwd(), projectPath);
+  const packageJsonPath = validateAndResolvePath(safeProjectPath, "package.json");
+  const tsconfigPath = validateAndResolvePath(safeProjectPath, "tsconfig.json");
   
   let projectInfo = {
     name: path.basename(projectPath),
@@ -66,16 +95,21 @@ async function analyzeProject(projectPath: string): Promise<{
   }
 
   // Check for common directories
+  const ALLOWED_DIRS = new Set(["src", "source", "lib", "dist", "build", "test", "tests", "__tests__"]);
   const commonDirs = ["src", "source", "lib", "dist", "build", "test", "tests", "__tests__"];
+  
   for (const dir of commonDirs) {
+    if (!ALLOWED_DIRS.has(dir)) continue; // Additional safety check
+    
     try {
-      const dirPath = path.join(projectPath, dir);
+      const dirPath = validateAndResolvePath(safeProjectPath, dir);
       const stat = await fs.stat(dirPath);
       if (stat.isDirectory()) {
         projectInfo.structure[dir] = "directory";
       }
-    } catch {
-      // Directory doesn't exist
+    } catch (error) {
+      // Log but don't expose error details
+      console.debug(`Directory check failed for ${dir}`);
     }
   }
 
@@ -185,9 +219,15 @@ export default {
   ArgumentsSchema,
   validate: async () => null,
   async run(abortSignal, call, config, modelOverride) {
-    const { projectPath = process.cwd() } = call.tool.arguments;
+    const { projectPath = "." } = call.tool.arguments;
     
     try {
+      // Validate input first
+      validateProjectPath(projectPath);
+      
+      // Get safe project path for file operations
+      const safeProjectPath = validateAndResolvePath(process.cwd(), projectPath);
+      
       // Analyze the project
       const projectInfo = await analyzeProject(projectPath);
       
@@ -198,7 +238,7 @@ export default {
       const octoContent = generateOctoMd(projectInfo, mcpInfo);
       
       // Write OCTO.md file
-      const octoPath = path.join(projectPath, "OCTO.md");
+      const octoPath = validateAndResolvePath(safeProjectPath, "OCTO.md");
       await fs.writeFile(octoPath, octoContent, "utf-8");
       
       return `✅ Project initialized successfully!
@@ -207,11 +247,12 @@ Generated OCTO.md with:
 - Project: ${projectInfo.name}
 - Features: ${projectInfo.features.join(", ") || "none detected"}
 - MCP Servers: ${mcpInfo.length} configured
-- File: ${octoPath}
+- File: OCTO.md
 
 The OCTO.md file contains comprehensive project documentation including available MCP tools.`;
     } catch (error) {
-      throw new ToolError(`Failed to initialize project: ${error instanceof Error ? error.message : String(error)}`);
+      console.error('Project initialization failed:', error);
+      throw new ToolError('Project initialization failed. Please check the project path and permissions.');
     }
   },
 } satisfies ToolDef<t.GetType<typeof Schema>>;

--- a/source/tools/tool-defs/init.ts
+++ b/source/tools/tool-defs/init.ts
@@ -246,7 +246,7 @@ export default {
         throw new ToolError('Failed to write project documentation file. Please check permissions.');
       }
       
-      return "✅ Project initialized successfully!\n\n" +
+      return "Project initialized successfully!\n\n" +
         "Generated OCTO.md with:\n" +
         "- Project: " + projectInfo.name + "\n" +
         "- Features: " + (projectInfo.features.join(", ") || "none detected") + "\n" +

--- a/source/tools/tool-defs/init.ts
+++ b/source/tools/tool-defs/init.ts
@@ -1,0 +1,217 @@
+import { t } from "structural";
+import * as fs from "fs/promises";
+import * as path from "path";
+import { ToolDef, ToolError } from "../common.ts";
+import { Config } from "../../config.ts";
+import { getMcpClient } from "./mcp.ts";
+
+const ArgumentsSchema = t.subtype({
+  projectPath: t.optional(t.str.comment("Path to the project directory (defaults to current directory)")),
+});
+
+const Schema = t.subtype({
+  name: t.value("init"),
+  arguments: ArgumentsSchema,
+}).comment("Initialize project documentation by analyzing structure and discovering MCP tools");
+
+async function analyzeProject(projectPath: string): Promise<{
+  name: string;
+  description: string;
+  features: string[];
+  structure: Record<string, string>;
+}> {
+  const packageJsonPath = path.join(projectPath, "package.json");
+  const tsconfigPath = path.join(projectPath, "tsconfig.json");
+  
+  let projectInfo = {
+    name: path.basename(projectPath),
+    description: "Project documentation",
+    features: [] as string[],
+    structure: {} as Record<string, string>,
+  };
+
+  try {
+    // Analyze package.json if it exists
+    const packageJson = JSON.parse(await fs.readFile(packageJsonPath, "utf-8"));
+    projectInfo.name = packageJson.name || projectInfo.name;
+    projectInfo.description = packageJson.description || projectInfo.description;
+    
+    if (packageJson.scripts) {
+      projectInfo.features.push("npm scripts");
+      Object.keys(packageJson.scripts).forEach(script => {
+        projectInfo.structure[`script:${script}`] = packageJson.scripts[script];
+      });
+    }
+    
+    if (packageJson.dependencies) {
+      projectInfo.features.push("Node.js dependencies");
+      projectInfo.structure["dependencies"] = Object.keys(packageJson.dependencies).length.toString();
+    }
+    
+    if (packageJson.devDependencies) {
+      projectInfo.features.push("Development dependencies");
+      projectInfo.structure["devDependencies"] = Object.keys(packageJson.devDependencies).length.toString();
+    }
+  } catch {
+    // package.json doesn't exist or is malformed
+  }
+
+  try {
+    // Check for TypeScript configuration
+    await fs.access(tsconfigPath);
+    projectInfo.features.push("TypeScript");
+    projectInfo.structure["typescript"] = "configured";
+  } catch {
+    // tsconfig.json doesn't exist
+  }
+
+  // Check for common directories
+  const commonDirs = ["src", "source", "lib", "dist", "build", "test", "tests", "__tests__"];
+  for (const dir of commonDirs) {
+    try {
+      const dirPath = path.join(projectPath, dir);
+      const stat = await fs.stat(dirPath);
+      if (stat.isDirectory()) {
+        projectInfo.structure[dir] = "directory";
+      }
+    } catch {
+      // Directory doesn't exist
+    }
+  }
+
+  return projectInfo;
+}
+
+async function discoverMcpTools(config: Config): Promise<Array<{
+  server: string;
+  command: string;
+  tools: Array<{ name: string; description?: string }>;
+}>> {
+  const mcpInfo = [];
+  
+  if (config.mcpServers) {
+    for (const [serverName, serverConfig] of Object.entries(config.mcpServers)) {
+      try {
+        const client = await getMcpClient(serverName, config);
+        const tools = await client.listTools();
+        mcpInfo.push({
+          server: serverName,
+          command: serverConfig.command,
+          tools: tools.tools.map(t => ({ 
+            name: t.name, 
+            description: t.description 
+          }))
+        });
+      } catch (error) {
+        // Log error but continue with other servers
+        mcpInfo.push({
+          server: serverName,
+          command: serverConfig.command,
+          tools: [{ name: "error", description: `Failed to connect: ${error}` }]
+        });
+      }
+    }
+  }
+  
+  return mcpInfo;
+}
+
+function generateOctoMd(
+  projectInfo: { name: string; description: string; features: string[]; structure: Record<string, string> },
+  mcpInfo: Array<{ server: string; command: string; tools: Array<{ name: string; description?: string }> }>
+): string {
+  const sections = [];
+  
+  // Header
+  sections.push(`# ${projectInfo.name}`);
+  sections.push("");
+  sections.push(projectInfo.description);
+  sections.push("");
+  
+  // Project Overview
+  sections.push("## Project Overview");
+  sections.push("");
+  if (projectInfo.features.length > 0) {
+    sections.push("**Features:**");
+    projectInfo.features.forEach(feature => {
+      sections.push(`- ${feature}`);
+    });
+    sections.push("");
+  }
+  
+  // Project Structure
+  if (Object.keys(projectInfo.structure).length > 0) {
+    sections.push("## Project Structure");
+    sections.push("");
+    Object.entries(projectInfo.structure).forEach(([key, value]) => {
+      sections.push(`- **${key}**: ${value}`);
+    });
+    sections.push("");
+  }
+  
+  // MCP Tools
+  if (mcpInfo.length > 0) {
+    sections.push("## Available MCP Tools");
+    sections.push("");
+    sections.push("This project is configured with the following MCP servers:");
+    sections.push("");
+    
+    mcpInfo.forEach(server => {
+      sections.push(`### ${server.server}`);
+      sections.push(`**Command**: \`${server.command}\``);
+      sections.push("");
+      sections.push("**Available Tools:**");
+      server.tools.forEach(tool => {
+        if (tool.description) {
+          sections.push(`- **${tool.name}**: ${tool.description}`);
+        } else {
+          sections.push(`- **${tool.name}**`);
+        }
+      });
+      sections.push("");
+    });
+  }
+  
+  // Footer
+  sections.push("---");
+  sections.push("");
+  sections.push("*Generated by octofriend `/init` command*");
+  
+  return sections.join("\n");
+}
+
+export default {
+  Schema,
+  ArgumentsSchema,
+  validate: async () => null,
+  async run(abortSignal, call, config, modelOverride) {
+    const { projectPath = process.cwd() } = call.tool.arguments;
+    
+    try {
+      // Analyze the project
+      const projectInfo = await analyzeProject(projectPath);
+      
+      // Discover MCP tools
+      const mcpInfo = await discoverMcpTools(config);
+      
+      // Generate OCTO.md content
+      const octoContent = generateOctoMd(projectInfo, mcpInfo);
+      
+      // Write OCTO.md file
+      const octoPath = path.join(projectPath, "OCTO.md");
+      await fs.writeFile(octoPath, octoContent, "utf-8");
+      
+      return `✅ Project initialized successfully!
+
+Generated OCTO.md with:
+- Project: ${projectInfo.name}
+- Features: ${projectInfo.features.join(", ") || "none detected"}
+- MCP Servers: ${mcpInfo.length} configured
+- File: ${octoPath}
+
+The OCTO.md file contains comprehensive project documentation including available MCP tools.`;
+    } catch (error) {
+      throw new ToolError(`Failed to initialize project: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  },
+} satisfies ToolDef<t.GetType<typeof Schema>>;

--- a/source/tools/tool-defs/init.ts
+++ b/source/tools/tool-defs/init.ts
@@ -239,7 +239,12 @@ export default {
       
       // Write OCTO.md file
       const octoPath = validateAndResolvePath(safeProjectPath, "OCTO.md");
-      await fs.writeFile(octoPath, octoContent, "utf-8");
+      try {
+        await fs.writeFile(octoPath, octoContent, "utf-8");
+      } catch (writeError) {
+        console.error('Failed to write OCTO.md:', writeError);
+        throw new ToolError('Failed to write project documentation file. Please check permissions.');
+      }
       
       return `✅ Project initialized successfully!
 

--- a/source/tools/tool-defs/init.ts
+++ b/source/tools/tool-defs/init.ts
@@ -108,8 +108,8 @@ async function analyzeProject(projectPath: string): Promise<{
         projectInfo.structure[dir] = "directory";
       }
     } catch (error) {
-      // Log but don't expose error details
-      console.debug(`Directory check failed for ${dir}`);
+      // Log but don't expose error details - directory doesn't exist, which is normal
+      // Removed console.debug to avoid cluttering production output
     }
   }
 
@@ -246,15 +246,13 @@ export default {
         throw new ToolError('Failed to write project documentation file. Please check permissions.');
       }
       
-      return `✅ Project initialized successfully!
-
-Generated OCTO.md with:
-- Project: ${projectInfo.name}
-- Features: ${projectInfo.features.join(", ") || "none detected"}
-- MCP Servers: ${mcpInfo.length} configured
-- File: OCTO.md
-
-The OCTO.md file contains comprehensive project documentation including available MCP tools.`;
+      return "✅ Project initialized successfully!\n\n" +
+        "Generated OCTO.md with:\n" +
+        "- Project: " + projectInfo.name + "\n" +
+        "- Features: " + (projectInfo.features.join(", ") || "none detected") + "\n" +
+        "- MCP Servers: " + mcpInfo.length + " configured\n" +
+        "- File: OCTO.md\n\n" +
+        "The OCTO.md file contains comprehensive project documentation including available MCP tools.";
     } catch (error) {
       console.error('Project initialization failed:', error);
       throw new ToolError('Project initialization failed. Please check the project path and permissions.');


### PR DESCRIPTION
## Summary
- Adds /init command for generating OCTO.md documentation
- Integrated with existing tools system (~280 lines)
- Users type /init to analyze project and generate documentation

## Changes
- Implements `/init` command in `source/tools/tool-defs/init.ts` with project analysis and MCP discovery
- Adds slash command detection in `source/state.ts` input function
- Integrates InitToolRenderer to `source/app.tsx` for UI
- Updates tool exports and output handling across the codebase

## Test Plan
- [ ] Verify `/init` command is detected when typed in input
- [ ] Test project analysis functionality
- [ ] Confirm OCTO.md generation works properly
- [ ] Validate MCP discovery integration

Total implementation: ~280 lines following octofriend patterns